### PR TITLE
상품상세 화면 : 이미지를 불러옴에 따라 생기는 화면 문제 해결

### DIFF
--- a/sangjo/src/main/webapp/WEB-INF/jsp/productInfo.jsp
+++ b/sangjo/src/main/webapp/WEB-INF/jsp/productInfo.jsp
@@ -3,9 +3,10 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core"  prefix = "c" %>
 <head>
 	<style>
-		/* 내부 링크 관련 */
-		.outer{
-			display: flex;
+		.outer h4{
+			overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 		}
 		.inner{
 			z-index: 10;
@@ -63,8 +64,9 @@
 					<div class="col-lg-6">
 						<div class="border rounded">
 							<a href="#"> 
-								<img src="${productMain.productImg}"
-									class="img-fluid rounded" alt="${productMain.productImg}">
+								<img src="img/product/${productMain.productImg}"
+									class="img-fluid rounded" alt="${productMain.productImg}"
+									style="width: 100%;">
 							</a>
 						</div>
 					</div>
@@ -202,7 +204,7 @@
 					<div class="border border-primary rounded position-relative vesitable-item outer">				
 						<a href="productInfo.do?productNo=${product.productNo }" class="link"></a>
 						<div class="vesitable-img">
-							<img src="${product.productImg }"
+							<img src="img/product/${product.productImg }"
 								class="img-fluid w-100 rounded-top" alt=""/>
 						</div>
 						<div
@@ -300,6 +302,9 @@
 				newPrice.unshift(',');
 			}
 			count++;
+		}
+		if(count == 4){
+			newPrice.shift();
 		}
 		return newPrice.join('');
 	}
@@ -401,7 +406,7 @@
 		})
 		reviewService.getReviewList({productMainNo,reviewPage},function(){
 			let result = JSON.parse(this.responseText);
-			console.log(result);
+			//console.log(result);
 			result.forEach(review => {
 				reviewDiv.appendChild(makeRow(review));
 			})


### PR DESCRIPTION
바뀐부분
1. 메인 제품의 이미지가 작게나와서 크게 출력하기위해 수정하였다.
2. 하단의 제품 리스트의 이미지들도 이상하게 나와서 수정하였다.
3. 하단 제품 리스트의 제목이 너무 길고 뒤죽박죽이라 임시조치로 수정하였다 향후 개발 방향성에 따라 다시 수정할 예정이다.